### PR TITLE
Add Apollo example

### DIFF
--- a/docs/example-apollo.md
+++ b/docs/example-apollo.md
@@ -1,0 +1,73 @@
+---
+id: example-apollo
+title: Apollo
+sidebar_label: Apollo
+---
+
+```javascript
+import React, { useState } from 'react';
+import { gql, useMutation } from 'react-apollo';
+import { MockedProvider } from '@apollo/react-testing'
+import { Button, TextInput, View } from 'react-native';
+import { render, fireEvent, act } from "@testing-library/react-native";
+import wait from "waait";
+
+const UPDATE_EMAIL = gql`
+    mutation UpdateEmail($email: String!) {
+        updateEmail(email: $email) {
+            newEmail
+        }
+    }
+`;
+
+function UpdateEmailForm() {
+    const [uppdateEmail, data] = useMutation(UPDATE_EMAIL);
+    const [email, setEmail] = useState('');
+
+    render() {
+        return (
+            <View>
+                <TextInput
+                    placeholder="Email"
+                    onChangeText={(text) => setEmail({ text })}
+                />
+                <Button onPress={() => {
+                    return updateEmail({
+                        variables: {
+                            email
+                        }
+                    })
+                }} title="Submit" />
+            </View>
+        );
+    }
+}
+
+function renderComponent(mocks = []) {
+    return render(
+        <MockedProvider mocks={mocks} addTypename={false}>
+            <UpdateEmailForm />
+        </>
+    )
+}
+
+describe("UpdateEmailForm", () => {
+    it("should update my email", async () => {
+        jest.useRealTimers();
+
+        const { getByPlaceholderText, getByText, queryByText } = renderComponent();
+
+        const emailInput = getByPlaceholderText("Email");
+        const sendLinkButton = getByText("update my email");
+
+        fireEvent.changeText(emailInput, "test@gmail.com");
+        fireEvent.pressOut(sendLinkButton);
+
+        await act(async () => {
+            await wait(0);
+        });
+
+        expect(queryByText(/Email successfully updated/)).toBeTruthy();
+    });
+});
+```


### PR DESCRIPTION
As Apollo becomes a more common tool for data fetching, there will be an increase of people looking to test their apollo implementations within their RN applications.

While there are a lot of similarities between RTL and RNTL, I felt that it's worth having a dedicated example in the docs, as there were a couple of gotchas that killed a couple of hours of my time